### PR TITLE
Sygnalizacja EOF podczas próby parse() na już pustym pliku

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.5)
 
 project(UXP1A_linda)
 include(CTest)

--- a/include/tuple_space/parsing/TupleParser.h
+++ b/include/tuple_space/parsing/TupleParser.h
@@ -20,6 +20,7 @@ private:
 
     void advance() const;
     bool is(PunctuationMark punctuation_mark) const;
+    bool is_eof() const;
     void skip(PunctuationMark punctuation_mark) const;
     bool try_skip_comma() const;
 

--- a/include/tuple_space/parsing/TupleTemplateElementParser.h
+++ b/include/tuple_space/parsing/TupleTemplateElementParser.h
@@ -21,6 +21,7 @@ private:
 
     void advance() const;
     bool is(PunctuationMark punctuation_mark) const;
+    bool is_eof() const;
     void skip(PunctuationMark punctuation_mark) const;
     bool try_skip_comma() const;
     TupleElement::Type read_type() const;

--- a/include/tuple_space/parsing/exceptions/ParseException.h
+++ b/include/tuple_space/parsing/exceptions/ParseException.h
@@ -19,4 +19,18 @@ public:
 	}
 };
 
+class EndOfFile : public std::runtime_error
+{
+public:
+    explicit EndOfFile(const std::string& _Message)
+        : runtime_error(_Message)
+    {
+    }
+
+    explicit EndOfFile(const char* const _Message)
+        : runtime_error(_Message)
+    {
+    }
+};
+
 #endif //UXP1A_LINDA_PARSEREXCEPTION_H

--- a/src/library_src/tuple_space/parsing/TupleParser.cpp
+++ b/src/library_src/tuple_space/parsing/TupleParser.cpp
@@ -31,9 +31,17 @@ void TupleParser::skip(PunctuationMark punctuation_mark) const
 {
     if (is(punctuation_mark))
         advance();
+    else if (is_eof())
+        throw EndOfFile("End of file at line: " + std::to_string(scanner->get_current_line()));
     else
         throw ParseException("Parse error: " + to_string(punctuation_mark) + " expected at line "
                              + std::to_string(scanner->get_current_line()));
+}
+
+bool TupleParser::is_eof() const
+{
+    const auto token = scanner->get_token();
+    return token.get_type() == Token::Type::Eof;
 }
 
 bool TupleParser::try_skip_comma() const

--- a/src/library_src/tuple_space/parsing/TupleTemplateElementParser.cpp
+++ b/src/library_src/tuple_space/parsing/TupleTemplateElementParser.cpp
@@ -69,11 +69,20 @@ bool TupleTemplateElementParser::is(PunctuationMark punctuation_mark) const
 
 void TupleTemplateElementParser::skip(PunctuationMark punctuation_mark) const
 {
+
     if (is(punctuation_mark))
         advance();
+    else if (is_eof())
+        throw EndOfFile("End of file at line: " + std::to_string(scanner->get_current_line()));
     else
         throw ParseException("Parse error: " + to_string(punctuation_mark) + " expected at line "
                              + std::to_string(scanner->get_current_line()));
+}
+
+bool TupleTemplateElementParser::is_eof() const
+{
+    const auto token = scanner->get_token();
+    return token.get_type() == Token::Type::Eof;
 }
 
 bool TupleTemplateElementParser::try_skip_comma() const

--- a/tests_src/unit_tests/parserTest/parserTest.cpp
+++ b/tests_src/unit_tests/parserTest/parserTest.cpp
@@ -38,3 +38,16 @@ BOOST_AUTO_TEST_CASE(parser_throws_on_missing_comma_between_elements)
 {
     BOOST_CHECK_THROW(get_parsed_tuple_element("(10 \"abc\")"), ParseException);
 }
+
+BOOST_AUTO_TEST_CASE(parser_throws_on_empty_file_end_of_file)
+{
+    BOOST_CHECK_THROW(get_parsed_tuple_element(""), EndOfFile);
+}
+
+BOOST_AUTO_TEST_CASE(parser_throws_end_of_file_after_last_read_tuple)
+{
+    std::istringstream inputStream("(10 ,\"abc\")");
+    TupleParser parser(std::make_unique<Scanner>(inputStream));
+    parser.parse();
+    BOOST_CHECK_THROW(parser.parse(), EndOfFile);
+}

--- a/tests_src/unit_tests/parserTest/tupleTemplatesTest.cpp
+++ b/tests_src/unit_tests/parserTest/tupleTemplatesTest.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 #include "tuple_space/parsing/TupleParser.h"
 #include "tuple_space/parsing/TupleTemplateElementParser.h"
+#include "tuple_space/parsing/exceptions/ParseException.h"
 
 namespace
 {
@@ -90,4 +91,24 @@ BOOST_AUTO_TEST_CASE(parser_parses_tuple_template_with_multiple_elements)
     BOOST_TEST(!tuple_template->matches(*tuple_wrong_string));
     BOOST_TEST(!tuple_template->matches(*tuple_one_element));
     BOOST_TEST(!tuple_template->matches(*tuple_three_elements));
+}
+
+BOOST_AUTO_TEST_CASE(end_of_file_if_nothing_to_parse)
+{
+    std::string input = "(integer:*, string:\"lol\")\n"
+                        "\n"
+                        "\n"
+                        "(integer:*, string:\"lol\")\n"
+                        "\n";
+    std::istringstream inputStream(input);
+    TupleTemplateElementParser parser(std::make_unique<Scanner>(inputStream));
+
+    // get 2 templates
+    for (int i = 0; i < 2; ++i)
+    {
+        parser.parse();
+    }
+
+    // expect end of file
+    BOOST_CHECK_THROW(parser.parse(), EndOfFile);
 }


### PR DESCRIPTION
Dość istotny element moim zdaniem. Dzięki temu można teraz robić coś takiego:
```c++
try {
    while(1) {
        auto tuple = parser.parse();
    }
} catch (EndOfFile) {
}
```